### PR TITLE
Add host-based task queue and timer

### DIFF
--- a/src/app/tasks/cpu_status_task.rs
+++ b/src/app/tasks/cpu_status_task.rs
@@ -1,4 +1,4 @@
-use super::task::BackgroundTask;
+use super::{queue::TaskQueue, task::BackgroundTask};
 use crate::app::states::{CpuInfo, SharedCpuInfo, SharedSshHosts, fetch_cpu_info};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ impl BackgroundTask for CpuInfoTask {
         Duration::from_secs(30)
     }
 
-    async fn run(&self) {
+    async fn run(&self, queue: Arc<TaskQueue>) {
         let hosts_info = {
             let hosts = self.ssh_hosts.lock().await;
             hosts.values().cloned().collect::<Vec<_>>()
@@ -29,33 +29,31 @@ impl BackgroundTask for CpuInfoTask {
         for info in hosts_info {
             let cpu_info = Arc::clone(&self.cpu_info);
             let host_id = info.id.clone();
+            queue
+                .enqueue(host_id.clone(), async move {
+                    {
+                        let mut statuses = cpu_info.lock().await;
+                        statuses.insert(host_id.clone(), CpuInfo::Loading);
+                    }
 
-            tokio::spawn(async move {
-                // Set temporary loading/failure status if desired
-                {
-                    let mut statuses = cpu_info.lock().await;
-                    statuses.insert(host_id.clone(), CpuInfo::Loading);
-                }
+                    let result = timeout(
+                        Duration::from_secs(10),
+                        task::spawn_blocking(move || fetch_cpu_info(&info)),
+                    )
+                    .await;
 
-                // Fetch info with timeout
-                let result = timeout(
-                    Duration::from_secs(10),
-                    task::spawn_blocking(move || fetch_cpu_info(&info)),
-                )
+                    let cpu_result = match result {
+                        Ok(Ok(info)) => info,
+                        Ok(Err(e)) => CpuInfo::failure(format!("Thread error: {e}")),
+                        Err(_) => CpuInfo::failure("Timed out"),
+                    };
+
+                    {
+                        let mut statuses = cpu_info.lock().await;
+                        statuses.insert(host_id, cpu_result);
+                    }
+                })
                 .await;
-
-                let cpu_result = match result {
-                    Ok(Ok(info)) => info,
-                    Ok(Err(e)) => CpuInfo::failure(format!("Thread error: {e}")),
-                    Err(_) => CpuInfo::failure("Timed out"),
-                };
-
-                // Update map
-                {
-                    let mut statuses = cpu_info.lock().await;
-                    statuses.insert(host_id, cpu_result);
-                }
-            });
         }
     }
 }

--- a/src/app/tasks/memory_task.rs
+++ b/src/app/tasks/memory_task.rs
@@ -1,4 +1,4 @@
-use super::task::BackgroundTask;
+use super::{queue::TaskQueue, task::BackgroundTask};
 use crate::app::states::{MemoryInfo, SharedMemoryInfo, SharedSshHosts, fetch_memory_info};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ impl BackgroundTask for MemoryInfoTask {
         Duration::from_secs(30)
     }
 
-    async fn run(&self) {
+    async fn run(&self, queue: Arc<TaskQueue>) {
         let hosts_info = {
             let hosts = self.ssh_hosts.lock().await;
             hosts.values().cloned().collect::<Vec<_>>()
@@ -29,30 +29,31 @@ impl BackgroundTask for MemoryInfoTask {
         for info in hosts_info {
             let memory_info = Arc::clone(&self.memory_info);
             let host_id = info.id.clone();
+            queue
+                .enqueue(host_id.clone(), async move {
+                    {
+                        let mut statuses = memory_info.lock().await;
+                        statuses.insert(host_id.clone(), MemoryInfo::Loading);
+                    }
 
-            tokio::spawn(async move {
-                {
-                    let mut statuses = memory_info.lock().await;
-                    statuses.insert(host_id.clone(), MemoryInfo::Loading);
-                }
+                    let result = timeout(
+                        Duration::from_secs(10),
+                        task::spawn_blocking(move || fetch_memory_info(&info)),
+                    )
+                    .await;
 
-                let result = timeout(
-                    Duration::from_secs(10),
-                    task::spawn_blocking(move || fetch_memory_info(&info)),
-                )
+                    let mem_result = match result {
+                        Ok(Ok(info)) => info,
+                        Ok(Err(e)) => MemoryInfo::failure(format!("Thread error: {e}")),
+                        Err(_) => MemoryInfo::failure("Timed out"),
+                    };
+
+                    {
+                        let mut statuses = memory_info.lock().await;
+                        statuses.insert(host_id, mem_result);
+                    }
+                })
                 .await;
-
-                let mem_result = match result {
-                    Ok(Ok(info)) => info,
-                    Ok(Err(e)) => MemoryInfo::failure(format!("Thread error: {e}")),
-                    Err(_) => MemoryInfo::failure("Timed out"),
-                };
-
-                {
-                    let mut statuses = memory_info.lock().await;
-                    statuses.insert(host_id, mem_result);
-                }
-            });
         }
     }
 }

--- a/src/app/tasks/mod.rs
+++ b/src/app/tasks/mod.rs
@@ -1,4 +1,5 @@
-pub mod executor;
+pub mod queue;
+pub mod timer;
 pub mod task;
 
 pub mod cpu_status_task;

--- a/src/app/tasks/os_task.rs
+++ b/src/app/tasks/os_task.rs
@@ -1,4 +1,4 @@
-use super::task::BackgroundTask;
+use super::{queue::TaskQueue, task::BackgroundTask};
 use crate::app::states::{OsInfo, SharedOsInfo, SharedSshHosts, fetch_os_info};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ impl BackgroundTask for OsInfoTask {
         Duration::from_secs(60 * 60)
     }
 
-    async fn run(&self) {
+    async fn run(&self, queue: Arc<TaskQueue>) {
         let hosts_info = {
             let hosts = self.ssh_hosts.lock().await;
             hosts.values().cloned().collect::<Vec<_>>()
@@ -29,30 +29,31 @@ impl BackgroundTask for OsInfoTask {
         for info in hosts_info {
             let os_info = Arc::clone(&self.os_info);
             let host_id = info.id.clone();
+            queue
+                .enqueue(host_id.clone(), async move {
+                    {
+                        let mut statuses = os_info.lock().await;
+                        statuses.insert(host_id.clone(), OsInfo::Loading);
+                    }
 
-            tokio::spawn(async move {
-                {
-                    let mut statuses = os_info.lock().await;
-                    statuses.insert(host_id.clone(), OsInfo::Loading);
-                }
+                    let result = timeout(
+                        Duration::from_secs(10),
+                        task::spawn_blocking(move || fetch_os_info(&info)),
+                    )
+                    .await;
 
-                let result = timeout(
-                    Duration::from_secs(10),
-                    task::spawn_blocking(move || fetch_os_info(&info)),
-                )
+                    let os_result = match result {
+                        Ok(Ok(info)) => info,
+                        Ok(Err(e)) => OsInfo::failure(format!("Thread error: {e}")),
+                        Err(_) => OsInfo::failure("Timed out"),
+                    };
+
+                    {
+                        let mut statuses = os_info.lock().await;
+                        statuses.insert(host_id, os_result);
+                    }
+                })
                 .await;
-
-                let os_result = match result {
-                    Ok(Ok(info)) => info,
-                    Ok(Err(e)) => OsInfo::failure(format!("Thread error: {e}")),
-                    Err(_) => OsInfo::failure("Timed out"),
-                };
-
-                {
-                    let mut statuses = os_info.lock().await;
-                    statuses.insert(host_id, os_result);
-                }
-            });
         }
     }
 }

--- a/src/app/tasks/queue.rs
+++ b/src/app/tasks/queue.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::{mpsc, Mutex, Semaphore};
+
+pub type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub struct TaskQueue {
+    senders: Mutex<HashMap<String, mpsc::Sender<BoxFuture>>>,
+    semaphore: Arc<Semaphore>,
+}
+
+impl TaskQueue {
+    pub fn new(max_concurrent_hosts: usize) -> Arc<Self> {
+        Arc::new(Self {
+            senders: Mutex::new(HashMap::new()),
+            semaphore: Arc::new(Semaphore::new(max_concurrent_hosts)),
+        })
+    }
+
+    pub async fn enqueue<F>(&self, host_id: String, fut: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let mut map = self.senders.lock().await;
+        if let Some(tx) = map.get(&host_id) {
+            let _ = tx.send(Box::pin(fut)).await;
+            return;
+        }
+
+        let (tx, mut rx) = mpsc::channel::<BoxFuture>(100);
+        tx.send(Box::pin(fut)).await.ok();
+        map.insert(host_id.clone(), tx);
+        let semaphore = Arc::clone(&self.semaphore);
+        tokio::spawn(async move {
+            while let Some(task) = rx.recv().await {
+                let permit = semaphore.acquire().await;
+                let _permit = permit.expect("semaphore closed");
+                task.await;
+                // permit dropped here
+            }
+        });
+    }
+}

--- a/src/app/tasks/ssh_status_task.rs
+++ b/src/app/tasks/ssh_status_task.rs
@@ -1,4 +1,4 @@
-use super::task::BackgroundTask;
+use super::{queue::TaskQueue, task::BackgroundTask};
 use crate::app::states::{SharedSshHosts, SharedSshStatuses, SshStatus, verify_connection};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ impl BackgroundTask for SshStatusTask {
         Duration::from_secs(120)
     }
 
-    async fn run(&self) {
+    async fn run(&self, queue: Arc<TaskQueue>) {
         let infos = {
             let hosts = self.ssh_hosts.lock().await;
             hosts.values().cloned().collect::<Vec<_>>() // Vec<SshHostInfo>
@@ -29,33 +29,31 @@ impl BackgroundTask for SshStatusTask {
         for info in infos {
             let id = info.id.clone();
             let statuses = Arc::clone(&self.ssh_statuses);
+            queue
+                .enqueue(id.clone(), async move {
+                    {
+                        let mut st = statuses.lock().await;
+                        st.insert(id.clone(), SshStatus::Loading);
+                    }
 
-            tokio::spawn(async move {
-                // Mark as loading
-                {
-                    let mut st = statuses.lock().await;
-                    st.insert(id.clone(), SshStatus::Loading);
-                }
+                    let result = timeout(
+                        Duration::from_secs(10),
+                        task::spawn_blocking(move || verify_connection(&info)),
+                    )
+                    .await;
 
-                // Perform the check with timeout
-                let result = timeout(
-                    Duration::from_secs(10),
-                    task::spawn_blocking(move || verify_connection(&info)),
-                )
+                    let status = match result {
+                        Ok(Ok(status)) => status,
+                        Ok(Err(e)) => SshStatus::Failed(format!("Thread error: {}", e)),
+                        Err(_) => SshStatus::Failed("Timed out".into()),
+                    };
+
+                    {
+                        let mut st = statuses.lock().await;
+                        st.insert(id, status);
+                    }
+                })
                 .await;
-
-                let status = match result {
-                    Ok(Ok(status)) => status,
-                    Ok(Err(e)) => SshStatus::Failed(format!("Thread error: {}", e)),
-                    Err(_) => SshStatus::Failed("Timed out".into()),
-                };
-
-                // Update status map
-                {
-                    let mut st = statuses.lock().await;
-                    st.insert(id, status);
-                }
-            });
         }
     }
 }

--- a/src/app/tasks/task.rs
+++ b/src/app/tasks/task.rs
@@ -1,4 +1,6 @@
+use std::sync::Arc;
 use tokio::time::Duration;
+use super::queue::TaskQueue;
 
 #[async_trait::async_trait]
 pub trait BackgroundTask: Send + Sync {
@@ -7,6 +9,6 @@ pub trait BackgroundTask: Send + Sync {
     /// The interval at which this task should repeat
     fn interval(&self) -> Duration;
 
-    /// The actual logic to run
-    async fn run(&self);
+    /// The actual logic to run. The queue will execute the work for each host.
+    async fn run(&self, queue: Arc<TaskQueue>);
 }

--- a/src/app/tasks/timer.rs
+++ b/src/app/tasks/timer.rs
@@ -1,13 +1,16 @@
+use super::queue::TaskQueue;
 use super::task::BackgroundTask;
-use tokio::time::sleep;
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
 
-pub struct TaskExecutor {
-    tasks: Vec<Box<dyn BackgroundTask>>,
+pub struct TaskTimer {
+    tasks: Vec<Box<dyn BackgroundTask>>, 
+    queue: Arc<TaskQueue>,
 }
 
-impl TaskExecutor {
-    pub fn new() -> Self {
-        Self { tasks: vec![] }
+impl TaskTimer {
+    pub fn new(queue: Arc<TaskQueue>) -> Self {
+        Self { tasks: vec![], queue }
     }
 
     pub fn register<T: BackgroundTask + 'static>(&mut self, task: T) {
@@ -17,11 +20,12 @@ impl TaskExecutor {
     pub fn start(self) {
         for task in self.tasks {
             let interval = task.interval();
+            let queue = Arc::clone(&self.queue);
             let name = task.name();
             tokio::spawn(async move {
                 loop {
                     tracing::debug!("Running task: {}", name);
-                    task.run().await;
+                    task.run(Arc::clone(&queue)).await;
                     sleep(interval).await;
                 }
             });


### PR DESCRIPTION
## Summary
- introduce `TaskQueue` for sequential per-host execution with global concurrency limit
- add `TaskTimer` to schedule tasks via the queue
- adapt all background tasks to enqueue jobs instead of spawning directly
- update app to use the new timer and queue

## Testing
- `cargo check` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6867198c03088321b7b76e1d07e24f57