### PR TITLE
Limit ssh concurrency

### DIFF
--- a/src/app/states/disk.rs
+++ b/src/app/states/disk.rs
@@ -1,5 +1,6 @@
 use super::ssh_hosts::SshHostInfo;
 use super::ssh_utils::{connect_ssh_session, run_command};
+use super::ssh_limits::SSH_LIMITER;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -34,6 +35,8 @@ impl DiskInfo {
 }
 
 pub fn fetch_disk_info(info: &SshHostInfo) -> DiskInfo {
+    let (_permit, _guard) = SSH_LIMITER.acquire(&info.id);
+
     let session = match connect_ssh_session(info) {
         Ok(s) => s,
         Err(e) => return DiskInfo::failure(e),

--- a/src/app/states/gpu.rs
+++ b/src/app/states/gpu.rs
@@ -1,5 +1,6 @@
 use super::ssh_hosts::SshHostInfo;
 use super::ssh_utils::{connect_ssh_session, run_command};
+use super::ssh_limits::SSH_LIMITER;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -42,6 +43,8 @@ impl GpuInfo {
 pub type SharedGpuInfo = Arc<Mutex<HashMap<String, GpuInfo>>>;
 
 pub fn fetch_gpu_info(info: &SshHostInfo) -> GpuInfo {
+    let (_permit, _guard) = SSH_LIMITER.acquire(&info.id);
+
     let session = match connect_ssh_session(info) {
         Ok(s) => s,
         Err(e) => return GpuInfo::failure(e),

--- a/src/app/states/memory.rs
+++ b/src/app/states/memory.rs
@@ -1,5 +1,6 @@
 use super::ssh_hosts::SshHostInfo;
 use super::ssh_utils::{connect_ssh_session, run_command};
+use super::ssh_limits::SSH_LIMITER;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -32,6 +33,8 @@ impl MemoryInfo {
 }
 
 pub fn fetch_memory_info(info: &SshHostInfo) -> MemoryInfo {
+    let (_permit, _guard) = SSH_LIMITER.acquire(&info.id);
+
     let session = match connect_ssh_session(info) {
         Ok(s) => s,
         Err(e) => return MemoryInfo::failure(e),

--- a/src/app/states/mod.rs
+++ b/src/app/states/mod.rs
@@ -6,6 +6,7 @@ pub mod os;
 pub mod ssh_hosts;
 pub mod ssh_status;
 pub mod ssh_utils;
+pub mod ssh_limits;
 
 pub use cpu::{CpuInfo, SharedCpuInfo, fetch_cpu_info};
 pub use disk::{DiskInfo, SharedDiskInfo, fetch_disk_info};
@@ -14,3 +15,4 @@ pub use memory::{MemoryInfo, SharedMemoryInfo, fetch_memory_info};
 pub use os::{OsInfo, SharedOsInfo, fetch_os_info};
 pub use ssh_hosts::{SharedSshHosts, SshHostInfo, load_ssh_configs};
 pub use ssh_status::{SharedSshStatuses, SshStatus, verify_connection};
+pub use ssh_limits::SSH_LIMITER;

--- a/src/app/states/os.rs
+++ b/src/app/states/os.rs
@@ -1,5 +1,6 @@
 use super::ssh_hosts::SshHostInfo;
 use super::ssh_utils::{connect_ssh_session, run_command};
+use super::ssh_limits::SSH_LIMITER;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -32,6 +33,8 @@ impl OsInfo {
 pub type SharedOsInfo = Arc<Mutex<HashMap<String, OsInfo>>>;
 
 pub fn fetch_os_info(info: &SshHostInfo) -> OsInfo {
+    let (_permit, _guard) = SSH_LIMITER.acquire(&info.id);
+
     let session = match connect_ssh_session(info) {
         Ok(s) => s,
         Err(e) => return OsInfo::failure(e),

--- a/src/app/states/ssh_limits.rs
+++ b/src/app/states/ssh_limits.rs
@@ -1,0 +1,42 @@
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Maximum number of concurrent SSH sessions allowed.
+/// This can be tuned as needed.
+const MAX_CONCURRENT: usize = 4;
+
+pub struct SshLimiter {
+    semaphore: Semaphore,
+    host_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+}
+
+impl SshLimiter {
+    const fn new(max: usize) -> Self {
+        Self {
+            semaphore: Semaphore::const_new(max),
+            host_locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn get_host_lock(&self, host_id: &str) -> Arc<Mutex<()>> {
+        let mut map = self.host_locks.lock();
+        map.entry(host_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    pub fn acquire(&self, host_id: &str) -> (OwnedSemaphorePermit, parking_lot::MutexGuard<'_, ()>) {
+        let permit = tokio::runtime::Handle::current()
+            .block_on(self.semaphore.acquire_owned())
+            .expect("Semaphore closed");
+
+        let host_lock = self.get_host_lock(host_id);
+        let guard = host_lock.lock();
+        (permit, guard)
+    }
+}
+
+pub static SSH_LIMITER: Lazy<SshLimiter> = Lazy::new(|| SshLimiter::new(MAX_CONCURRENT));


### PR DESCRIPTION
## Summary
- add `SSH_LIMITER` to serialize connections per host and cap global connections
- use limiter in all SSH-related fetch functions

## Testing
- `cargo check` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686f3be3d6a08321aa186750b7f72d96